### PR TITLE
Add a 'tip' to use DeviceClass enums

### DIFF
--- a/docs/core/entity/cover.md
+++ b/docs/core/entity/cover.md
@@ -30,18 +30,22 @@ Properties should always only return information from memory and not do I/O (lik
 
 ### Device Classes
 
-| Constant | Description
+:::tip
+When specifying a device class, you should use the `CoverDeviceClass` enum. For example when specifying the type `awning` from below you should use `CoverDeviceClass.AWNING`.
+:::
+
+| Type | Description
 |----------|-----------------------|
-| `DEVICE_CLASS_AWNING` | Control of an awning, such as an exterior retractible window, door, or patio cover.
-| `DEVICE_CLASS_BLIND` | Control of blinds, which are linked slats that expand or collapse to cover an opening or may be tilted to partially cover an opening, such as window blinds.
-| `DEVICE_CLASS_CURTAIN` | Control of curtains or drapes, which is often fabric hung above a window or door that can be drawn open.
-| `DEVICE_CLASS_DAMPER` | Control of a mechanical damper that reduces air flow, sound, or light.
-| `DEVICE_CLASS_DOOR` | Control of a door that provides access to an area which is typically part of a structure.
-| `DEVICE_CLASS_GARAGE` | Control of a garage door that provides access to a garage.
-| `DEVICE_CLASS_GATE` | Control of a gate that provides access to a driveway or other area. Gates are found outside of a structure and are typically part of a fence.
-| `DEVICE_CLASS_SHADE` | Control of shades, which are a continuous plane of material or connected cells that expanded or collapsed over an opening, such as window shades.
-| `DEVICE_CLASS_SHUTTER` | Control of shutters, which are linked slats that swing out/in to cover an opening or may be tilted to partially cover an opening, such as indoor or exterior window shutters.
-| `DEVICE_CLASS_WINDOW` | Control of a physical window that opens and closes or may tilt.
+| `awning` | Control of an awning, such as an exterior retractible window, door, or patio cover.
+| `blind` | Control of blinds, which are linked slats that expand or collapse to cover an opening or may be tilted to partially cover an opening, such as window blinds.
+| `curtain` | Control of curtains or drapes, which is often fabric hung above a window or door that can be drawn open.
+| `damper` | Control of a mechanical damper that reduces air flow, sound, or light.
+| `door` | Control of a door that provides access to an area which is typically part of a structure.
+| `garage` | Control of a garage door that provides access to a garage.
+| `gate` | Control of a gate that provides access to a driveway or other area. Gates are found outside of a structure and are typically part of a fence.
+| `shade` | Control of shades, which are a continuous plane of material or connected cells that expanded or collapsed over an opening, such as window shades.
+| `shutter` | Control of shutters, which are linked slats that swing out/in to cover an opening or may be tilted to partially cover an opening, such as indoor or exterior window shutters.
+| `window` | Control of a physical window that opens and closes or may tilt.
 
 ### States
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Recently @frenck began prompting `custom_component` owners to move from `DEVICE_CLASS_*` to the `DeviceClass` enums. This is not explicitly stated, so I've added it as a tip. I've also cleaned the cover documentation to remove the `DEVICE_CLASS_*` constant values mentioned.


## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
