### PR TITLE
Add a 'tip' to use BinarySensorDeviceClass enum

### DIFF
--- a/docs/core/entity/binary-sensor.md
+++ b/docs/core/entity/binary-sensor.md
@@ -18,7 +18,11 @@ Properties should always only return information from memory and not do I/O (lik
 
 ### Available device classes
 
-| Value | Description
+:::tip
+When specifying a device class, you should use the `BinarySensorDeviceClass` enum. For example when specifying the type `battery` from below you should use `BinarySensorDeviceClass.BATTERY`.
+:::
+
+| Type | Description
 | ----- | -----------
 | battery | On means low, Off means normal.
 | battery_charging | On means charging, Off means not charging.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Recently @frenck began prompting `custom_component` owners to move from `DEVICE_CLASS_*` to the `DeviceClass` enums. This is not explicitly stated, so I've added it as a tip.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Developer Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Document existing features within Home Assistant
- [ ] Document new or changing features which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Removed stale or deprecated documentation

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
  
  For documentation relating to existing code please link to the relevant file on the appropriate master or dev branch (i.e.: https://github.com/home-assistant/core/blob/7c784b69638f3e2b3c91294b31a62e1058ba9709/homeassistant/components/random/sensor.py#L48-L57)

  For documentation relating to new or changing code, please link to the corresponding pull request (i.e. home-assistant/core#2). This lets us easily check the status of your proposal.
-->

- This PR fixes or closes issue: fixes #
- Link to relevant existing code or pull request: 
